### PR TITLE
Fix data loading race

### DIFF
--- a/js/affixSplitter.js
+++ b/js/affixSplitter.js
@@ -28,8 +28,8 @@ async function loadAffixData() {
   }
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-  loadAffixData();
+window.addEventListener('DOMContentLoaded', async () => {
+  await loadAffixData();
   const form = document.getElementById('affix-form');
   form.addEventListener('submit', onFormSubmit);
 });


### PR DESCRIPTION
## Summary
- ensure affix data is loaded before enabling the form

## Testing
- `node --check js/affixSplitter.js`


------
https://chatgpt.com/codex/tasks/task_e_68422a563e00832db1eb8ba1c6913754